### PR TITLE
Erase the extra space in the helm install command for the CRDs chart

### DIFF
--- a/src/app/docs/kagent/introduction/installation/page.mdx
+++ b/src/app/docs/kagent/introduction/installation/page.mdx
@@ -57,7 +57,7 @@ Another way to install kagent is using Helm.
 1. Install the kagent Helm chart with CRDs.
 
    ```bash
-   helm install kagent-crds oci://ghcr.io/kagent-dev/   kagent/helm/kagent-crds \
+   helm install kagent-crds oci://ghcr.io/kagent-dev/kagent/helm/kagent-crds \
        --namespace kagent \
        --create-namespace
    ```


### PR DESCRIPTION
The helm install command was broken. Now it works.